### PR TITLE
Add cookie function

### DIFF
--- a/src/main/kotlin/com/jobobby/missing/Main.kt
+++ b/src/main/kotlin/com/jobobby/missing/Main.kt
@@ -9,6 +9,7 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.expectSuccess
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logging
+import io.ktor.client.request.cookie
 import io.ktor.client.request.get
 import io.ktor.client.request.headers
 import io.ktor.client.statement.bodyAsText
@@ -27,6 +28,7 @@ import org.jsoup.Jsoup
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.slf4j.impl.SimpleLogger
+import java.io.File
 import java.util.concurrent.TimeUnit
 import kotlin.io.path.Path
 import kotlin.io.path.deleteIfExists
@@ -76,6 +78,13 @@ suspend fun main(args: Array<String>) {
     val client = HttpClient(OkHttp) {
         engine {
             addInterceptor(RateLimitInterceptor(2, 1, TimeUnit.SECONDS))
+        }
+        val cookies = File("cookie.txt")
+        if (cookies.exists()) {
+            val loginCookie = cookies.readText()
+            install(DefaultRequest) {
+                cookie(name = "fakku_sid", value = loginCookie)
+            }
         }
         install(ContentNegotiation) {
             json()


### PR DESCRIPTION
Add the ability to pull the cookie from an external cookie.txt file in the same folder as the jar itself.  The cookie.txt file only has the value of fakku_sid and will import it directly to a variable.  This allows for access to information that only shows when you are logged in like controversial content.  Related to https://github.com/jobobby04/LanraragiMissingGalleries/issues/1